### PR TITLE
Resolve Issue 3

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -36,3 +36,20 @@
         hasDropdown.forEach(activateDropdownTrigger);
     }
 )();
+
+/*
+ * Updates the underline for each navigation bar menu item
+ *
+ * @param	{string} pageName	Name of current page
+ */
+var updateNavbarUnderlines = function (pageName) {
+	var menuItems = document.getElementsByClassName("mssg-link");
+	for (item of menuItems) {
+		if (item.id === pageName) {
+			item.classList.add("link-active");
+		}
+		else {
+			item.classList.remove("link-active");
+		}
+	}
+}

--- a/templates/about/main.html
+++ b/templates/about/main.html
@@ -102,3 +102,5 @@
 	</div>
 
 </div>
+
+<script>updateNavbarUnderlines("about");</script>

--- a/templates/competitions/main.html
+++ b/templates/competitions/main.html
@@ -1,1 +1,3 @@
 <h1>Competitions</h1>
+
+<script>updateNavbarUnderlines("competitions");</script>

--- a/templates/index/main.html
+++ b/templates/index/main.html
@@ -15,3 +15,5 @@
 		</div>
 	</div>
 </div>
+
+<script>updateNavbarUnderlines("index");</script>

--- a/templates/navbar/main.html
+++ b/templates/navbar/main.html
@@ -1,10 +1,10 @@
 <div class="mssg-nav">
 	<div class="mssg-logo"><a href="/landing-page/#!"><img src="/landing-page/assets/img/mssg100.png"/></a></div>
 	<div class="mssg-links">
-		<div class="mssg-link link-active">
+		<div id="index" class="mssg-link">
 			<a href="/landing-page/#!">Home</a>
 		</div>
-		<div class="mssg-link has-dropdown">
+		<div id="about" class="mssg-link has-dropdown">
 			<a href="/landing-page/#!/about">About Us</a>
 			<i class="ion-chevron-down dd-trigger"></i>
 			<div class="mssg-dropdown">
@@ -37,7 +37,7 @@
 				 </div>
 			</div>
 		</div>
-		<div class="mssg-link has-dropdown">
+		<div id="research" class="mssg-link has-dropdown">
 			<a href="/landing-page/#!/research">Research</a>
 			<i class="ion-chevron-down dd-trigger"></i>
 			 <div class="mssg-dropdown">
@@ -55,7 +55,7 @@
 				 </div>
 			</div>
 		</div>
-		<div class="mssg-link has-dropdown link-active">
+		<div id="competitions" class="mssg-link has-dropdown">
 			<a href="/landing-page/#!/competitions">Competitions</a>
 			<i class="ion-chevron-down dd-trigger"></i>
 			 <div class="mssg-dropdown">
@@ -73,7 +73,7 @@
 				 </div>
 			</div>
 		</div>
-		 <div class="mssg-link">
+		 <div id="sponsorships" class="mssg-link">
 			<a href="/landing-page/#!/sponsorships">Sponsorships</a>
 		</div>
 	</div>

--- a/templates/research/main.html
+++ b/templates/research/main.html
@@ -1,1 +1,3 @@
 <h1>Research</h1>
+
+<script>updateNavbarUnderlines("research");</script>

--- a/templates/sponsorships/main.html
+++ b/templates/sponsorships/main.html
@@ -1,1 +1,3 @@
 <h1>Sponsorship</h1>
+
+<script>updateNavbarUnderlines("sponsorships");</script>


### PR DESCRIPTION
The objective of the changes in this Pull Request is to resolve Issue 3.

A script has been added to dropdown.js that updates the underline for each navigation bar menu item by adding or removing the "link-active" class from the menu item "mssg-link" class element. This script is called by each page and fed the name of the particular page from which it is called. In addition, the hardcoded "link-active" classes have been removed from the navigation bar main.html file.

Related Items:

[Issue 3: Navbar links underline doesn't update with URL changes](https://github.com/mcgillspace/landing-page/issues/3)